### PR TITLE
WIP: VideoRecorderクラスの抽出作業

### DIFF
--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -226,7 +226,7 @@ class CameraFragment : Fragment() {
         //  session.stopRepeating() is called
         session.setRepeatingRequest(previewRequest, null, cameraHandler)
 
-        _videoRecorder.setup(session, listOf(viewFinder.holder.surface), relativeOrientation)
+        _videoRecorder.setup(session, listOf(viewFinder.holder.surface))
 
         // React to user touching the capture button
         capture_button.setOnClickListener { _ ->
@@ -239,7 +239,7 @@ class CameraFragment : Fragment() {
                         requireActivity().requestedOrientation =
                                 ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
-                        videoRecordingSession = videoRecorder.startRecordingSession()
+                        videoRecordingSession = videoRecorder.startRecordingSession(relativeOrientation.value)
                         Log.d(TAG, "Recording started")
 
                         // Starts recording animation

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -17,6 +17,7 @@
 package com.example.android.camera2.video.fragments
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.graphics.Color
@@ -62,7 +63,7 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 class CameraFragment : Fragment() {
-    private val videoRecorder by lazy { VideoRecorder(requireContext(), Size(args.width, args.height), args.fps) }
+    private val videoRecorder by lazy { VideoRecorder(requireContext(), Size(args.width, args.height), args.fps, false) }
 
     private var isRecording = false
 
@@ -75,8 +76,10 @@ class CameraFragment : Fragment() {
     }
 
     /** Detects, characterizes, and connects to a CameraDevice (used for all camera operations) */
-    private val cameraManager: CameraManager
-        get() = videoRecorder.cameraManager
+    private val cameraManager: CameraManager by lazy {
+        val context = requireContext().applicationContext
+        context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+    }
 
     /** [CameraCharacteristics] corresponding to the provided Camera ID */
     private val characteristics: CameraCharacteristics by lazy {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -26,6 +26,7 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CaptureRequest
+import android.media.MediaScannerConnection
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
@@ -252,6 +253,10 @@ class CameraFragment : Fragment() {
                     val outputFile: File
                     try {
                         outputFile = videoRecordingSession.stopRecording()
+                        // Broadcasts the media file to the rest of the system
+                        MediaScannerConnection.scanFile(
+                                context, arrayOf(outputFile.absolutePath), null, null)
+
                     } catch (e: RecordingException) {
                         Log.d(TAG, "failed to stop recording: $e")
                         return@whenResumed

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -67,8 +67,6 @@ class CameraFragment : Fragment() {
     private var videoRecordingSession: VideoRecorderSession? = null
     private val videoRecorder by lazy { VideoRecorder(requireContext(), Size(args.width, args.height), args.fps, false) }
 
-    private var isRecording = false
-
     /** AndroidX navigation arguments */
     private val args: CameraFragmentArgs by navArgs()
 
@@ -202,9 +200,8 @@ class CameraFragment : Fragment() {
         // React to user touching the capture button
         capture_button.setOnClickListener { _ ->
             lifecycleScope.launch(Dispatchers.IO) {
-                Log.d(TAG, "inomata onclick isrecording=$isRecording")
-                if (!isRecording) {
-                    isRecording = true
+                Log.d(TAG, "inomata onclick isrecording=${videoRecordingSession != null}")
+                if (videoRecordingSession == null) {
                     // Prevents screen rotation during the video recording
                     requireActivity().requestedOrientation =
                             ActivityInfo.SCREEN_ORIENTATION_LOCKED
@@ -216,8 +213,6 @@ class CameraFragment : Fragment() {
                     overlay.post(animationTask)
                     return@launch
                 }
-
-                isRecording = false
 
                 val outputFile: File
                 try {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -210,7 +210,7 @@ class CameraFragment : Fragment() {
                 VideoRecorderConfiguration(
                         Size(args.width, args.height),
                         args.fps,
-                        false,
+                        true,
                         VideoRecorder.createFile(requireContext())
                 )
         )

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -53,7 +53,6 @@ import com.example.android.camera2.video.CameraActivity
 import com.example.android.camera2.video.R
 import com.example.android.camera2.video.recorder.VideoRecorder
 import com.example.android.camera2.video.recorder.VideoRecorderSession
-import com.example.android.camera2.video.recorder.getPreviewOutputSize
 import kotlinx.android.synthetic.main.fragment_camera.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -195,7 +195,7 @@ class CameraFragment : Fragment() {
         //  session.stopRepeating() is called
         session.setRepeatingRequest(previewRequest, null, cameraHandler)
 
-        videoRecorder.prepare(session, listOf(viewFinder.holder.surface), relativeOrientation)
+        videoRecorder.setup(session, listOf(viewFinder.holder.surface), relativeOrientation)
 
         // React to user touching the capture button
         capture_button.setOnClickListener { _ ->

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -353,17 +353,19 @@ class CameraFragment : Fragment() {
         super.onStop()
         Log.d(TAG, "onStop()")
         isCameraActive = false
-        try {
-            val videoRecordingSession = videoRecordingSession
-            if (videoRecordingSession != null) {
-                videoRecordingSession.cancel()
-                clearRecordingState()
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val videoRecordingSession = videoRecordingSession
+                if (videoRecordingSession != null) {
+                    videoRecordingSession.cancel()
+                    clearRecordingState()
+                }
+                videoRecorder?.release()
+                videoRecorder = null
+                camera.close()
+            } catch (exc: Throwable) {
+                Log.e(TAG, "Error closing camera", exc)
             }
-            videoRecorder?.release()
-            videoRecorder = null
-            camera.close()
-        } catch (exc: Throwable) {
-            Log.e(TAG, "Error closing camera", exc)
         }
     }
 

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -302,6 +302,7 @@ class CameraFragment : Fragment() {
 
     override fun onStop() {
         super.onStop()
+        Log.d(TAG, "onStop()")
         try {
             camera.close()
         } catch (exc: Throwable) {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -47,7 +47,7 @@ import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import com.example.android.camera.utils.AutoFitSurfaceView
-import com.example.android.camera.utils.OrientationLiveData
+import com.example.android.camera2.video.recorder.OrientationLiveData
 import com.example.android.camera2.video.BuildConfig
 import com.example.android.camera2.video.CameraActivity
 import com.example.android.camera2.video.R

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -52,13 +52,14 @@ import com.example.android.camera2.video.BuildConfig
 import com.example.android.camera2.video.CameraActivity
 import com.example.android.camera2.video.R
 import com.example.android.camera2.video.recorder.VideoRecorder
+import com.example.android.camera2.video.recorder.VideoRecorderConfiguration
 import com.example.android.camera2.video.recorder.VideoRecorderSession
+import com.example.android.camera2.video.recorder.getPreviewOutputSize
 import kotlinx.android.synthetic.main.fragment_camera.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.io.File
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -186,7 +187,15 @@ class CameraFragment : Fragment() {
         // Open the selected camera
         camera = openCamera(cameraManager, args.cameraId, cameraHandler)
 
-        val _videoRecorder = VideoRecorder(requireContext(), Size(args.width, args.height), args.fps, false)
+        val _videoRecorder = VideoRecorder(
+                requireContext(),
+                VideoRecorderConfiguration(
+                        Size(args.width, args.height),
+                        args.fps,
+                        false,
+                        VideoRecorder.createFile(requireContext())
+                )
+        )
         this@CameraFragment.videoRecorder = _videoRecorder
 
         // Creates list of Surfaces where the camera will output frames

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -30,6 +30,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
+import android.util.Range
 import android.util.Size
 import android.view.LayoutInflater
 import android.view.Surface
@@ -209,7 +210,7 @@ class CameraFragment : Fragment() {
                 requireContext(),
                 VideoRecorderConfiguration(
                         Size(args.width, args.height),
-                        args.fps,
+                        Range(args.fps, args.fps),
                         true,
                         VideoRecorder.createFile(requireContext())
                 )

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -62,7 +62,7 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 class CameraFragment : Fragment() {
-    private val videoRecorder by lazy { VideoRecorder(requireContext(), cameraHandler, Size(args.width, args.height), args.fps) }
+    private val videoRecorder by lazy { VideoRecorder(requireContext(), Size(args.width, args.height), args.fps) }
 
     private var isRecording = false
 
@@ -205,6 +205,7 @@ class CameraFragment : Fragment() {
                             ActivityInfo.SCREEN_ORIENTATION_LOCKED
 
                     videoRecorder.startRecording()
+                    Log.d(TAG, "Recording started")
 
                     // Starts recording animation
                     overlay.post(animationTask)
@@ -216,6 +217,7 @@ class CameraFragment : Fragment() {
                 val outputFile: File
                 try {
                     outputFile = videoRecorder.stopRecording()
+                    Log.d(TAG, "Recording stopped. Output file: $outputFile")
                 } finally {
                     // Unlocks screen rotation after recording finished
                     requireActivity().requestedOrientation =

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -154,12 +154,15 @@ class CameraFragment : Fragment() {
         })
 
         // Used to rotate the output media to match device orientation
-        videoRecorder.relativeOrientation = OrientationLiveData(requireContext(), characteristics).apply {
+        relativeOrientation = OrientationLiveData(requireContext(), characteristics).apply {
             observe(viewLifecycleOwner, Observer {
                 orientation -> Log.d(TAG, "Orientation changed: $orientation")
             })
         }
     }
+
+    /** Live data listener for changes in the device orientation relative to the camera */
+    lateinit var relativeOrientation: OrientationLiveData
 
     /**
      * Begin all camera operations in a coroutine in the main thread. This function:
@@ -183,7 +186,7 @@ class CameraFragment : Fragment() {
         //  session.stopRepeating() is called
         session.setRepeatingRequest(previewRequest, null, cameraHandler)
 
-        videoRecorder.previewSurface = viewFinder.holder.surface
+        videoRecorder.prepare(session, viewFinder.holder.surface, relativeOrientation)
 
         // React to user touching the capture button
         capture_button.setOnClickListener { _ ->
@@ -208,8 +211,6 @@ class CameraFragment : Fragment() {
                 navController.popBackStack()
             }
         }
-
-        videoRecorder.session = session
     }
 
     /** Opens the camera and returns the opened device (as the result of the suspend coroutine) */

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -17,6 +17,7 @@
 package com.example.android.camera2.video.fragments
 
 import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
@@ -194,7 +195,11 @@ class CameraFragment : Fragment() {
                 Log.d(TAG, "inomata onclick isrecording=$isRecording")
                 if (!isRecording) {
                     isRecording = true
-                    videoRecorder.startRecording(requireActivity())
+                    // Prevents screen rotation during the video recording
+                    requireActivity().requestedOrientation =
+                            ActivityInfo.SCREEN_ORIENTATION_LOCKED
+
+                    videoRecorder.startRecording()
 
                     // Starts recording animation
                     overlay.post(animationTask)
@@ -203,7 +208,14 @@ class CameraFragment : Fragment() {
 
                 isRecording = false
 
-                videoRecorder.stopRecording(requireActivity())
+                try {
+                    videoRecorder.stopRecording()
+                } finally {
+                    // Unlocks screen rotation after recording finished
+                    requireActivity().requestedOrientation =
+                            ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                }
+
                 // Removes recording animation
                 overlay.removeCallbacks(animationTask)
                 // Finishes our current camera screen

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -192,7 +192,7 @@ class CameraFragment : Fragment() {
         //  session.stopRepeating() is called
         session.setRepeatingRequest(previewRequest, null, cameraHandler)
 
-        videoRecorder.prepare(session, viewFinder.holder.surface, relativeOrientation)
+        videoRecorder.prepare(session, listOf(viewFinder.holder.surface), relativeOrientation)
 
         // React to user touching the capture button
         capture_button.setOnClickListener { _ ->

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt
@@ -17,31 +17,22 @@
 package com.example.android.camera2.video.fragments
 
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CaptureRequest
-import android.media.MediaCodec
-import android.media.MediaRecorder
-import android.media.MediaScannerConnection
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
-import android.util.Range
 import android.util.Size
 import android.view.LayoutInflater
 import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.MimeTypeMap
-import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -51,7 +42,6 @@ import androidx.navigation.Navigation
 import androidx.navigation.fragment.navArgs
 import com.example.android.camera.utils.AutoFitSurfaceView
 import com.example.android.camera.utils.OrientationLiveData
-import com.example.android.camera2.video.BuildConfig
 import com.example.android.camera2.video.CameraActivity
 import com.example.android.camera2.video.R
 import com.example.android.camera2.video.recorder.VideoRecorder
@@ -61,7 +51,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.io.File
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/PermissionsFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/PermissionsFragment.kt
@@ -16,7 +16,6 @@
 
 package com.example.android.camera2.video.fragments
 
-import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -26,11 +25,10 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import com.example.android.camera2.video.R
+import com.example.android.camera2.video.recorder.VideoRecorder
 
 private const val PERMISSIONS_REQUEST_CODE = 10
-private val PERMISSIONS_REQUIRED = arrayOf(
-        Manifest.permission.CAMERA,
-        Manifest.permission.RECORD_AUDIO)
+private const val RECORD_WITH_AUDIO = true
 
 /**
  * This [Fragment] requests permissions and, once granted, it will navigate to the next fragment
@@ -47,7 +45,7 @@ class PermissionsFragment : Fragment() {
                     PermissionsFragmentDirections.actionPermissionsToSelector())
         } else {
             // Request camera-related permissions
-            requestPermissions(PERMISSIONS_REQUIRED, PERMISSIONS_REQUEST_CODE)
+            requestPermissions(VideoRecorder.getRequiredPermissions(withAudio = RECORD_WITH_AUDIO), PERMISSIONS_REQUEST_CODE)
         }
     }
 
@@ -68,8 +66,6 @@ class PermissionsFragment : Fragment() {
     companion object {
 
         /** Convenience method used to check if all permissions required by this app are granted */
-        fun hasPermissions(context: Context) = PERMISSIONS_REQUIRED.all {
-            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-        }
+        fun hasPermissions(context: Context) = VideoRecorder.hasEnoughPermissions(context, withAudio = RECORD_WITH_AUDIO)
     }
 }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/PermissionsFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/PermissionsFragment.kt
@@ -20,6 +20,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -38,6 +39,7 @@ class PermissionsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d("PermissionFragment", "onCreate()")
 
         if (hasPermissions(requireContext())) {
             // If permissions have already been granted, proceed

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/SelectorFragment.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/SelectorFragment.kt
@@ -22,6 +22,7 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.media.MediaRecorder
 import android.os.Bundle
+import android.util.Log
 import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
@@ -49,6 +50,7 @@ class SelectorFragment : Fragment() {
     @SuppressLint("MissingPermission")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        Log.d("SelectorFragment", "onViewCreated()")
         view as RecyclerView
         view.apply {
             layoutManager = LinearLayoutManager(requireContext())

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
@@ -25,7 +25,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 /** Helper class used to pre-compute shortest and longest sides of a [Size] */
-class SmartSize(width: Int, height: Int) {
+internal class SmartSize(width: Int, height: Int) {
     var size = Size(width, height)
     var long = max(size.width, size.height)
     var short = min(size.width, size.height)
@@ -33,10 +33,10 @@ class SmartSize(width: Int, height: Int) {
 }
 
 /** Standard High Definition size for pictures and video */
-val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
+internal val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
 
 /** Returns a [SmartSize] object for the given [Display] */
-fun getDisplaySmartSize(display: Display): SmartSize {
+internal fun getDisplaySmartSize(display: Display): SmartSize {
     val outPoint = Point()
     display.getRealSize(outPoint)
     return SmartSize(outPoint.x, outPoint.y)
@@ -47,7 +47,7 @@ fun getDisplaySmartSize(display: Display): SmartSize {
  * https://d.android.com/reference/android/hardware/camera2/CameraDevice and
  * https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
  */
-fun <T>getPreviewOutputSize(
+internal fun <T>getPreviewOutputSize(
         display: Display,
         characteristics: CameraCharacteristics,
         targetClass: Class<T>,

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
@@ -1,3 +1,6 @@
+// android/camera-samples から複製
+// https://github.com/android/camera-samples/blob/2b446855ca2662db42ff1755968f6af495c2a962/Camera2Basic/utils/src/main/java/com/example/android/camera/utils/CameraSizes.kt
+
 /*
  * Copyright 2020 The Android Open Source Project
  *
@@ -25,7 +28,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 /** Helper class used to pre-compute shortest and longest sides of a [Size] */
-internal class SmartSize(width: Int, height: Int) {
+class SmartSize(width: Int, height: Int) {
     var size = Size(width, height)
     var long = max(size.width, size.height)
     var short = min(size.width, size.height)
@@ -33,10 +36,10 @@ internal class SmartSize(width: Int, height: Int) {
 }
 
 /** Standard High Definition size for pictures and video */
-internal val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
+val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
 
 /** Returns a [SmartSize] object for the given [Display] */
-internal fun getDisplaySmartSize(display: Display): SmartSize {
+fun getDisplaySmartSize(display: Display): SmartSize {
     val outPoint = Point()
     display.getRealSize(outPoint)
     return SmartSize(outPoint.x, outPoint.y)
@@ -47,7 +50,7 @@ internal fun getDisplaySmartSize(display: Display): SmartSize {
  * https://d.android.com/reference/android/hardware/camera2/CameraDevice and
  * https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
  */
-internal fun <T>getPreviewOutputSize(
+fun <T>getPreviewOutputSize(
         display: Display,
         characteristics: CameraCharacteristics,
         targetClass: Class<T>,

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/CameraSizes.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.camera2.video.recorder
+
+import android.graphics.Point
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.params.StreamConfigurationMap
+import android.util.Size
+import android.view.Display
+import kotlin.math.max
+import kotlin.math.min
+
+/** Helper class used to pre-compute shortest and longest sides of a [Size] */
+class SmartSize(width: Int, height: Int) {
+    var size = Size(width, height)
+    var long = max(size.width, size.height)
+    var short = min(size.width, size.height)
+    override fun toString() = "SmartSize(${long}x${short})"
+}
+
+/** Standard High Definition size for pictures and video */
+val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
+
+/** Returns a [SmartSize] object for the given [Display] */
+fun getDisplaySmartSize(display: Display): SmartSize {
+    val outPoint = Point()
+    display.getRealSize(outPoint)
+    return SmartSize(outPoint.x, outPoint.y)
+}
+
+/**
+ * Returns the largest available PREVIEW size. For more information, see:
+ * https://d.android.com/reference/android/hardware/camera2/CameraDevice and
+ * https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
+ */
+fun <T>getPreviewOutputSize(
+        display: Display,
+        characteristics: CameraCharacteristics,
+        targetClass: Class<T>,
+        format: Int? = null
+): Size {
+
+    // Find which is smaller: screen or 1080p
+    val screenSize = getDisplaySmartSize(display)
+    val hdScreen = screenSize.long >= SIZE_1080P.long || screenSize.short >= SIZE_1080P.short
+    val maxSize = if (hdScreen) SIZE_1080P else screenSize
+
+    // If image format is provided, use it to determine supported sizes; else use target class
+    val config = characteristics.get(
+            CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)!!
+    if (format == null)
+        assert(StreamConfigurationMap.isOutputSupportedFor(targetClass))
+    else
+        assert(config.isOutputSupportedFor(format))
+    val allSizes = if (format == null)
+        config.getOutputSizes(targetClass) else config.getOutputSizes(format)
+
+    // Get available sizes and sort them by area from largest to smallest
+    val validSizes = allSizes
+            .sortedWith(compareBy { it.height * it.width })
+            .map { SmartSize(it.width, it.height) }.reversed()
+
+    // Then, get the largest output size that is smaller or equal than our max size
+    return validSizes.first { it.long <= maxSize.long && it.short <= maxSize.short }.size
+}

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
@@ -4,6 +4,9 @@ import android.media.MediaRecorder
 import android.view.Surface
 import java.io.File
 
+/**
+ * recorder パッケージ内で使うためのMediaRecorderインスタンス生成器
+ */
 internal class MediaRecorderFactory() {
     /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
     fun create(configuration: VideoRecorderConfiguration, inputSurface: Surface, outputFile: File? = null, dummy: Boolean = false) = MediaRecorder().apply {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
@@ -11,6 +11,10 @@ internal class MediaRecorderFactory() {
     /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
     fun create(configuration: VideoRecorderConfiguration, inputSurface: Surface, outputFile: File? = null, dummy: Boolean = false) = MediaRecorder().apply {
         setVideoSource(MediaRecorder.VideoSource.SURFACE)
+        if (configuration.withAudio) {
+            // setOutputFormat の前に呼ばなければならない
+            setAudioSource(MediaRecorder.AudioSource.MIC)
+        }
         setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
         setOutputFile(configuration.outputFile.absolutePath)
         setVideoEncodingBitRate(VIDEO_BITRATE)
@@ -18,8 +22,8 @@ internal class MediaRecorderFactory() {
         setVideoSize(configuration.videoSize.width, configuration.videoSize.height)
         setVideoEncoder(MediaRecorder.VideoEncoder.H264)
         if (configuration.withAudio) {
-            setAudioSource(MediaRecorder.AudioSource.MIC)
             setAudioSamplingRate(AUDIO_SAMPLING_RATE)
+            // setOutputFormat の後に呼ばなければならない
             setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
         }
         setInputSurface(inputSurface)

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
@@ -1,0 +1,34 @@
+package com.example.android.camera2.video.recorder
+
+import android.media.MediaRecorder
+import android.view.Surface
+import java.io.File
+
+internal class MediaRecorderFactory() {
+    /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
+    fun create(configuration: VideoRecorderConfiguration, inputSurface: Surface, outputFile: File? = null, dummy: Boolean = false) = MediaRecorder().apply {
+        setVideoSource(MediaRecorder.VideoSource.SURFACE)
+        setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+        setOutputFile(configuration.outputFile.absolutePath)
+        setVideoEncodingBitRate(VIDEO_BITRATE)
+        if (configuration.videoFps > 0) setVideoFrameRate(configuration.videoFps)
+        setVideoSize(configuration.videoSize.width, configuration.videoSize.height)
+        setVideoEncoder(MediaRecorder.VideoEncoder.H264)
+        if (configuration.withAudio) {
+            setAudioSource(MediaRecorder.AudioSource.MIC)
+            setAudioSamplingRate(AUDIO_SAMPLING_RATE)
+            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        }
+        setInputSurface(inputSurface)
+
+        if (dummy) {
+            prepare()
+            release()
+        }
+    }
+
+    companion object {
+        const val VIDEO_BITRATE: Int = 10_000_000
+        const val AUDIO_SAMPLING_RATE: Int = 16_000
+    }
+}

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/MediaRecorderFactory.kt
@@ -18,7 +18,7 @@ internal class MediaRecorderFactory() {
         setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
         setOutputFile(configuration.outputFile.absolutePath)
         setVideoEncodingBitRate(VIDEO_BITRATE)
-        if (configuration.videoFps > 0) setVideoFrameRate(configuration.videoFps)
+        if (configuration.videoFps != null) setVideoFrameRate(configuration.videoFps.lower) // upper とどっちがいいか？
         setVideoSize(configuration.videoSize.width, configuration.videoSize.height)
         setVideoEncoder(MediaRecorder.VideoEncoder.H264)
         if (configuration.withAudio) {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/OrientationLiveData.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/OrientationLiveData.kt
@@ -1,0 +1,97 @@
+// android/camera-samples から複製
+// https://github.com/techvein/camera-samples/blob/2a6b5bd9b8a8d732536e65d1716c2aed1f879101/CameraUtils/lib/src/main/java/com/example/android/camera/utils/OrientationLiveData.kt
+package com.example.android.camera2.video.recorder
+
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.view.OrientationEventListener
+import android.view.Surface
+import androidx.lifecycle.LiveData
+
+
+/**
+ * Calculates closest 90-degree orientation to compensate for the device
+ * rotation relative to sensor orientation, i.e., allows user to see camera
+ * frames with the expected orientation.
+ */
+class OrientationLiveData(
+    context: Context,
+    characteristics: CameraCharacteristics
+): LiveData<Int>() {
+
+    private val listener = object : OrientationEventListener(context.applicationContext) {
+        override fun onOrientationChanged(orientation: Int) {
+            val rotation = when {
+                orientation <= 45 -> Surface.ROTATION_0
+                orientation <= 135 -> Surface.ROTATION_90
+                orientation <= 225 -> Surface.ROTATION_180
+                orientation <= 315 -> Surface.ROTATION_270
+                else -> Surface.ROTATION_0
+            }
+            val relative = computeRelativeRotation(characteristics, rotation)
+            if (relative != value) postValue(relative)
+        }
+    }
+
+    override fun onActive() {
+        super.onActive()
+        listener.enable()
+    }
+
+    override fun onInactive() {
+        super.onInactive()
+        listener.disable()
+    }
+
+    companion object {
+
+        /**
+         * Computes rotation required to transform from the camera sensor orientation to the
+         * device's current orientation in degrees.
+         *
+         * @param characteristics the [CameraCharacteristics] to query for the sensor orientation.
+         * @param surfaceRotation the current device orientation as a Surface constant
+         * @return the relative rotation from the camera sensor to the current device orientation.
+         */
+        @JvmStatic
+        private fun computeRelativeRotation(
+            characteristics: CameraCharacteristics,
+            surfaceRotation: Int
+        ): Int {
+            val sensorOrientationDegrees =
+                characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)!!
+
+            val deviceOrientationDegrees = when (surfaceRotation) {
+                Surface.ROTATION_0 -> 0
+                Surface.ROTATION_90 -> 90
+                Surface.ROTATION_180 -> 180
+                Surface.ROTATION_270 -> 270
+                else -> 0
+            }
+
+            // Reverse device orientation for front-facing cameras
+            val sign = if (characteristics.get(CameraCharacteristics.LENS_FACING) ==
+                CameraCharacteristics.LENS_FACING_FRONT) 1 else -1
+
+            // Calculate desired JPEG orientation relative to camera orientation to make
+            // the image upright relative to the device orientation
+            return (sensorOrientationDegrees - (deviceOrientationDegrees * sign) + 360) % 360
+        }
+    }
+}

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/RecordingException.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/RecordingException.kt
@@ -1,0 +1,9 @@
+package com.example.android.camera2.video.recorder
+
+/**
+ * 録画失敗例外。早すぎる stop() 時に発生する。
+ */
+class RecordingException(
+    message: String? = null,
+    cause: RuntimeException? = null)
+    : Throwable(message ?: cause?.toString(), cause)

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoCameraHelper.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoCameraHelper.kt
@@ -1,0 +1,44 @@
+package com.example.android.camera2.video.recorder
+
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.media.MediaRecorder
+import android.util.Size
+
+/**
+ * 録画カメラ用ヘルパ
+ */
+class VideoCameraHelper(
+    private val cameraManager: CameraManager,
+    val cameraId: String
+) {
+    private val characteristics by lazy { cameraManager.getCameraCharacteristics(cameraId) }
+    private val capabilities by lazy {
+        characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES)
+    }
+    private val cameraConfig by lazy {
+        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+    }
+
+    /**
+     * 録画に使える(MediaRecorderに対応している)カメラか。
+     */
+    fun isRecordableCamera()
+        = capabilities?.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_BACKWARD_COMPATIBLE) ?: false
+
+    /**
+     * 指定サイズにおけるFPSを計算する。何らかの理由で計算できない場合は0を返す。
+     */
+    fun getFps(size: Size): Int {
+        val cameraConfig = cameraConfig ?: return 0
+
+        // Recording should always be done in the most efficient format, which is
+        //  the format native to the camera framework
+        val targetClass = MediaRecorder::class.java
+        val secondsPerFrame =
+                cameraConfig.getOutputMinFrameDuration(targetClass, size) /
+                        1_000_000_000.0
+        return if (secondsPerFrame > 0) (1.0 / secondsPerFrame).toInt() else 0
+
+    }
+}

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -61,19 +61,10 @@ class VideoRecorder (
         surface
     }
 
-    private var recorderSession: VideoRecorderSession? = null
-
-    suspend fun startRecording() {
-        val recorderSession = VideoRecorderSession(context, configuration, mediaRecorderFactory, handler, recorderSurface, extraSurfaces, session, relativeOrientation)
+    suspend fun startRecordingSession(): VideoRecorderSession {
+        val recorderSession = VideoRecorderSessionImpl(context, configuration, mediaRecorderFactory, handler, recorderSurface, extraSurfaces, session, relativeOrientation)
         recorderSession.startRecording()
-        this.recorderSession = recorderSession
-    }
-
-    suspend fun stopRecording(): File {
-        val recorderSession = recorderSession ?: throw IllegalStateException("recording not started")
-        val res = recorderSession.stopRecording()
-        this.recorderSession = null
-        return res
+        return recorderSession
     }
 
     fun release() {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -84,7 +84,7 @@ class VideoRecorder(
         context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
     }
 
-    private val recorder: MediaRecorder by lazy { createRecorder(recorderSurface) }
+    private lateinit var recorder: MediaRecorder
 
     /** Requests used for preview and recording in the [CameraCaptureSession] */
     private val recordRequest: CaptureRequest by lazy {
@@ -119,6 +119,7 @@ class VideoRecorder(
 
     suspend fun startRecording() {
         mutex.withLock {
+            recorder = createRecorder(recorderSurface)
             log("startRecording(): start")
             // camera-samples サンプルでは setRepeatingRequest は listener=nullでもhandlerを指定していますが、
             // ドキュメントからもAOSPソースからもhandlerはlistenerの反応スレッドを制御するためだけに使われるようなので、handlerは使わないことにしました。

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -32,6 +32,8 @@ class VideoRecorder(
     private val videoSize: Size,
     /** ビデオ録画FPS */
     private val videoFps: Int,
+    /** 音声録画するか */
+    private val withAudio: Boolean,
     /** 出力ファイルパス。省略時は自動で生成します。 */
     outputFile: File? = null
 ) {
@@ -77,13 +79,6 @@ class VideoRecorder(
 //    private var mediaRecorder: MediaRecorder? = null
     private var recordingStartMillis: Long = 0L
 
-
-    /** Detects, characterizes, and connects to a CameraDevice (used for all camera operations) */
-    val cameraManager: CameraManager by lazy {
-        val context = context.applicationContext
-        context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-    }
-
     private lateinit var recorder: MediaRecorder
 
     /** Requests used for preview and recording in the [CameraCaptureSession] */
@@ -99,16 +94,18 @@ class VideoRecorder(
     }
     /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
     private fun createRecorder(surface: Surface, dummy: Boolean = false) = MediaRecorder().apply {
-        setAudioSource(MediaRecorder.AudioSource.MIC)
         setVideoSource(MediaRecorder.VideoSource.SURFACE)
         setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
         setOutputFile(outputFile.absolutePath)
-        setAudioSamplingRate(AUDIO_SAMPLING_RATE)
         setVideoEncodingBitRate(VideoRecorder.VIDEO_BITRATE)
         if (videoFps > 0) setVideoFrameRate(videoFps)
         setVideoSize(videoSize.width, videoSize.height)
         setVideoEncoder(MediaRecorder.VideoEncoder.H264)
-        setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        if (withAudio) {
+            setAudioSource(MediaRecorder.AudioSource.MIC)
+            setAudioSamplingRate(AUDIO_SAMPLING_RATE)
+            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        }
         setInputSurface(surface)
 
         if (dummy) {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -24,8 +24,6 @@ class VideoRecorder (
     /** 利用側でプレビューなどに使うsurface群 */
     private var extraSurfaces = ArrayList<Surface>()
     private lateinit var session: CameraCaptureSession
-    /** Live data listener for changes in the device orientation relative to the camera */
-    private lateinit var relativeOrientation: OrientationLiveData
 
     private val mediaRecorderFactory = MediaRecorderFactory()
 
@@ -46,9 +44,9 @@ class VideoRecorder (
         surface
     }
 
-    suspend fun startRecordingSession(): VideoRecorderSession {
-        val recorderSession = VideoRecorderSessionImpl(context, configuration, mediaRecorderFactory, recorderSurface, extraSurfaces, session, relativeOrientation)
-        recorderSession.startRecording()
+    suspend fun startRecordingSession(orientationDegree: Int?): VideoRecorderSession {
+        val recorderSession = VideoRecorderSessionImpl(context, configuration, mediaRecorderFactory, recorderSurface, extraSurfaces, session)
+        recorderSession.startRecording(orientationDegree)
         return recorderSession
     }
 
@@ -56,10 +54,9 @@ class VideoRecorder (
         recorderSurface.release()
     }
 
-    fun setup(session: CameraCaptureSession, extraSurfaces: List<Surface> = emptyList(), relativeOrientation: OrientationLiveData) {
+    fun setup(session: CameraCaptureSession, extraSurfaces: List<Surface> = emptyList()) {
         this.extraSurfaces = ArrayList(extraSurfaces)
         this.session = session
-        this.relativeOrientation = relativeOrientation
     }
 
     /** 権限が足りているかのチェックをして、1つでも足りてなければ false を返す。 */

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -7,7 +7,6 @@ import android.hardware.camera2.CameraCaptureSession
 import android.media.MediaCodec
 import android.view.Surface
 import androidx.core.content.ContextCompat
-import com.example.android.camera.utils.OrientationLiveData
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.hardware.camera2.CameraCaptureSession
 import android.media.MediaCodec
-import android.os.Handler
-import android.os.HandlerThread
 import android.view.Surface
 import androidx.core.content.ContextCompat
 import com.example.android.camera.utils.OrientationLiveData
@@ -24,11 +22,6 @@ class VideoRecorder (
     private val context: Context,
     private val configuration: VideoRecorderConfiguration
 ) {
-    /** [HandlerThread] where all camera operations run */
-    private val backgroundThread = HandlerThread("VideoCallbackThread").apply { start() }
-    /** [Handler] corresponding to [cameraThread] */
-    private val handler  = Handler(backgroundThread.looper)
-
     /** 利用側でプレビューなどに使うsurface群 */
     private var extraSurfaces = ArrayList<Surface>()
     private lateinit var session: CameraCaptureSession
@@ -55,14 +48,13 @@ class VideoRecorder (
     }
 
     suspend fun startRecordingSession(): VideoRecorderSession {
-        val recorderSession = VideoRecorderSessionImpl(context, configuration, mediaRecorderFactory, handler, recorderSurface, extraSurfaces, session, relativeOrientation)
+        val recorderSession = VideoRecorderSessionImpl(context, configuration, mediaRecorderFactory, recorderSurface, extraSurfaces, session, relativeOrientation)
         recorderSession.startRecording()
         return recorderSession
     }
 
     fun release() {
         recorderSurface.release()
-        backgroundThread.quitSafely()
     }
 
     fun setup(session: CameraCaptureSession, extraSurfaces: List<Surface> = emptyList(), relativeOrientation: OrientationLiveData) {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -64,14 +64,14 @@ class VideoRecorder (
     }
 
     /** 権限が足りているかのチェックをして、1つでも足りてなければ false を返す。 */
-    fun hasPermissions() = requiredPermissions().all {
+    fun hasEnoughPermissions() = getRequiredPermissions().all {
         ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
     }
 
     /**
      * このインスタンス設定で必要なパーミッション一覧を取得する。
      */
-    fun requiredPermissions() = requiredPermissions(configuration.withAudio)
+    fun getRequiredPermissions() = getRequiredPermissions(configuration.withAudio)
 
     companion object {
         /** Creates a [File] named with the current date and time */
@@ -89,7 +89,7 @@ class VideoRecorder (
         /**
          * 必要なパーミッション。
          */
-        fun requiredPermissions(withAudio: Boolean): Array<String> {
+        fun getRequiredPermissions(withAudio: Boolean): Array<String> {
             return arrayOf(Manifest.permission.CAMERA) +
                     if(withAudio) { arrayOf(Manifest.permission.RECORD_AUDIO) } else emptyArray()
         }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -26,7 +26,7 @@ class VideoRecorder (
     private val context: Context,
     /** ビデオ録画サイズ */
     videoSize: Size,
-    /** ビデオ録画FPS */
+    /** ビデオ録画FPS。VideoCameraHelper::getFps()で計算可能です。 */
     videoFps: Int,
     /** 音声録画するか */
     withAudio: Boolean,

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -93,5 +93,10 @@ class VideoRecorder (
             return arrayOf(Manifest.permission.CAMERA) +
                     if(withAudio) { arrayOf(Manifest.permission.RECORD_AUDIO) } else emptyArray()
         }
+
+        /** 権限が足りているかのチェックをして、1つでも足りてなければ false を返す。 */
+        fun hasEnoughPermissions(context: Context, withAudio: Boolean) = getRequiredPermissions(withAudio = withAudio).all {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        }
     }
 }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -7,7 +7,6 @@ import android.hardware.camera2.CameraCaptureSession
 import android.media.MediaCodec
 import android.os.Handler
 import android.os.HandlerThread
-import android.util.Log
 import android.util.Size
 import android.view.Surface
 import androidx.core.content.ContextCompat

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -7,7 +7,6 @@ import android.hardware.camera2.CameraCaptureSession
 import android.media.MediaCodec
 import android.os.Handler
 import android.os.HandlerThread
-import android.util.Size
 import android.view.Surface
 import androidx.core.content.ContextCompat
 import com.example.android.camera.utils.OrientationLiveData
@@ -23,26 +22,12 @@ import java.util.*
  */
 class VideoRecorder (
     private val context: Context,
-    /** ビデオ録画サイズ */
-    videoSize: Size,
-    /** ビデオ録画FPS。VideoCameraHelper::getFps()で計算可能です。 */
-    videoFps: Int,
-    /** 音声録画するか */
-    withAudio: Boolean,
-    /** 出力ファイルパス。省略時は自動で生成します。 */
-    outputFile: File? = null
+    private val configuration: VideoRecorderConfiguration
 ) {
     /** [HandlerThread] where all camera operations run */
     private val backgroundThread = HandlerThread("VideoCallbackThread").apply { start() }
     /** [Handler] corresponding to [cameraThread] */
     private val handler  = Handler(backgroundThread.looper)
-
-    private val configuration: VideoRecorderConfiguration = VideoRecorderConfiguration(
-            videoSize = videoSize,
-            videoFps = videoFps,
-            withAudio = withAudio,
-            outputFile = outputFile ?: createFile(context)
-    )
 
     /** 利用側でプレビューなどに使うsurface群 */
     private var extraSurfaces = ArrayList<Surface>()
@@ -97,8 +82,6 @@ class VideoRecorder (
     fun requiredPermissions() = requiredPermissions(configuration.withAudio)
 
     companion object {
-        private val TAG = VideoRecorder::class.java.simpleName
-
         /** Creates a [File] named with the current date and time */
         fun createFile(context: Context): File {
             val sdf = SimpleDateFormat("yyyy_MM_dd_HH_mm_ss_SSS", Locale.US)

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -108,11 +108,7 @@ class VideoRecorder(
         }
     }
 
-    fun startRecording(activity: Activity) {
-        // Prevents screen rotation during the video recording
-        activity.requestedOrientation =
-                ActivityInfo.SCREEN_ORIENTATION_LOCKED
-
+    fun startRecording() {
         // Start recording repeating requests, which will stop the ongoing preview
         //  repeating requests without having to explicitly call `session.stopRepeating`
         session.setRepeatingRequest(recordRequest, null, handler)
@@ -129,11 +125,7 @@ class VideoRecorder(
         Log.d(TAG, "Recording started")
     }
 
-    suspend fun stopRecording(activity: Activity) {
-        // Unlocks screen rotation after recording finished
-        activity.requestedOrientation =
-                ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-
+    suspend fun stopRecording() {
         // Requires recording of at least MIN_REQUIRED_RECORDING_TIME_MILLIS
         val elapsedTimeMillis = System.currentTimeMillis() - recordingStartMillis
         if (elapsedTimeMillis < VideoRecorder.MIN_REQUIRED_RECORDING_TIME_MILLIS) {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -1,0 +1,21 @@
+package com.example.android.camera2.video.recorder
+
+import android.content.Context
+import android.media.MediaRecorder
+import android.net.Uri
+import android.util.Size
+
+class VideoRecorder(context: Context) {
+    private lateinit var videoSize: Size
+
+    /**
+     * Output file for video
+     */
+    val videoUri: Uri?
+        get() = if (nextVideoAbsolutePath != null) {
+            Uri.parse(nextVideoAbsolutePath)
+        } else null
+    private var nextVideoAbsolutePath: String? = null
+    private var mediaRecorder: MediaRecorder? = null
+
+}

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -32,8 +32,11 @@ class VideoRecorder(
     private val videoSize: Size,
     private val videoFps: Int
 ) {
-    lateinit var session: CameraCaptureSession
-    lateinit var previewSurface: Surface
+    private lateinit var session: CameraCaptureSession
+    private lateinit var previewSurface: Surface
+    /** Live data listener for changes in the device orientation relative to the camera */
+    private lateinit var relativeOrientation: OrientationLiveData
+
 
     /**
      * Setup a persistent [Surface] for the recorder so we can use it as an output target for the
@@ -74,10 +77,6 @@ class VideoRecorder(
 
     /** File where the recording will be saved */
     private val outputFile: File by lazy { createFile(context, "mp4") }
-
-    /** Live data listener for changes in the device orientation relative to the camera */
-    lateinit var relativeOrientation: OrientationLiveData
-
 
     /** Requests used for preview and recording in the [CameraCaptureSession] */
     private val recordRequest: CaptureRequest by lazy {
@@ -164,6 +163,12 @@ class VideoRecorder(
     fun release() {
         recorder.release()
         recorderSurface.release()
+    }
+
+    fun prepare(session: CameraCaptureSession, previewSurface: Surface, relativeOrientation: OrientationLiveData) {
+        this.previewSurface = previewSurface
+        this.session = session
+        this.relativeOrientation = relativeOrientation
     }
 
     companion object {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -1,12 +1,56 @@
 package com.example.android.camera2.video.recorder
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
+import android.media.MediaCodec
 import android.media.MediaRecorder
+import android.media.MediaScannerConnection
 import android.net.Uri
+import android.os.Handler
+import android.util.Log
+import android.util.Range
 import android.util.Size
+import android.view.Surface
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import com.example.android.camera.utils.OrientationLiveData
+import com.example.android.camera2.video.BuildConfig
+import kotlinx.coroutines.delay
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 
-class VideoRecorder(context: Context) {
-    private lateinit var videoSize: Size
+class VideoRecorder(
+    private val context: Context,
+    private val handler: Handler,
+    private val videoSize: Size,
+    private val videoFps: Int
+) {
+    lateinit var session: CameraCaptureSession
+    lateinit var previewSurface: Surface
+
+    /**
+     * Setup a persistent [Surface] for the recorder so we can use it as an output target for the
+     * camera session without preparing the recorder
+     */
+    val recorderSurface: Surface by lazy {
+
+        // Get a persistent Surface from MediaCodec, don't forget to release when done
+        val surface = MediaCodec.createPersistentInputSurface()
+
+        // Prepare and release a dummy MediaRecorder with our new surface
+        // Required to allocate an appropriately sized buffer before passing the Surface as the
+        //  output target to the capture session
+        createRecorder(surface, dummy = true)
+
+        surface
+    }
 
     /**
      * Output file for video
@@ -17,5 +61,120 @@ class VideoRecorder(context: Context) {
         } else null
     private var nextVideoAbsolutePath: String? = null
     private var mediaRecorder: MediaRecorder? = null
+    var recordingStartMillis: Long = 0L
 
+
+    /** Detects, characterizes, and connects to a CameraDevice (used for all camera operations) */
+    val cameraManager: CameraManager by lazy {
+        val context = context.applicationContext
+        context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+    }
+
+    private val recorder: MediaRecorder by lazy { createRecorder(recorderSurface) }
+
+    /** File where the recording will be saved */
+    private val outputFile: File by lazy { createFile(context, "mp4") }
+
+    /** Live data listener for changes in the device orientation relative to the camera */
+    lateinit var relativeOrientation: OrientationLiveData
+
+
+    /** Requests used for preview and recording in the [CameraCaptureSession] */
+    private val recordRequest: CaptureRequest by lazy {
+        // Capture request holds references to target surfaces
+        session.device.createCaptureRequest(CameraDevice.TEMPLATE_RECORD).apply {
+            // Add the preview and recording surface targets
+            addTarget(previewSurface)
+            addTarget(recorderSurface)
+            // Sets user requested FPS for all targets
+            set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(videoFps, videoFps))
+        }.build()
+    }
+    /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
+    fun createRecorder(surface: Surface, dummy: Boolean = false) = MediaRecorder().apply {
+        setAudioSource(MediaRecorder.AudioSource.MIC)
+        setVideoSource(MediaRecorder.VideoSource.SURFACE)
+        setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+        setOutputFile(outputFile.absolutePath)
+        setVideoEncodingBitRate(VideoRecorder.RECORDER_VIDEO_BITRATE)
+        if (videoFps > 0) setVideoFrameRate(videoFps)
+        setVideoSize(videoSize.width, videoSize.height)
+        setVideoEncoder(MediaRecorder.VideoEncoder.H264)
+        setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        setInputSurface(surface)
+
+        if (dummy) {
+            prepare()
+            release()
+        }
+    }
+
+    fun startRecording(activity: Activity) {
+        // Prevents screen rotation during the video recording
+        activity.requestedOrientation =
+                ActivityInfo.SCREEN_ORIENTATION_LOCKED
+
+        // Start recording repeating requests, which will stop the ongoing preview
+        //  repeating requests without having to explicitly call `session.stopRepeating`
+        session.setRepeatingRequest(recordRequest, null, handler)
+
+        // Finalizes recorder setup and starts recording
+        recorder.apply {
+            Log.d(TAG, "inomata Recorder started.")
+            // Sets output orientation based on current sensor value at start time
+            relativeOrientation.value?.let { setOrientationHint(it) }
+            prepare()
+            start()
+        }
+        recordingStartMillis = System.currentTimeMillis()
+        Log.d(TAG, "Recording started")
+    }
+
+    suspend fun stopRecording(activity: Activity) {
+        // Unlocks screen rotation after recording finished
+        activity.requestedOrientation =
+                ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+
+        // Requires recording of at least MIN_REQUIRED_RECORDING_TIME_MILLIS
+        val elapsedTimeMillis = System.currentTimeMillis() - recordingStartMillis
+        if (elapsedTimeMillis < VideoRecorder.MIN_REQUIRED_RECORDING_TIME_MILLIS) {
+            delay(MIN_REQUIRED_RECORDING_TIME_MILLIS - elapsedTimeMillis)
+        }
+
+        Log.d(TAG, "Recording stopped. Output file: $outputFile")
+        recorder.stop()
+
+        // Broadcasts the media file to the rest of the system
+        MediaScannerConnection.scanFile(
+                context, arrayOf(outputFile.absolutePath), null, null)
+
+        // Launch external activity via intent to play video recorded using our provider
+        context.startActivity(Intent().apply {
+            action = Intent.ACTION_VIEW
+            type = MimeTypeMap.getSingleton()
+                    .getMimeTypeFromExtension(outputFile.extension)
+            val authority = "${BuildConfig.APPLICATION_ID}.provider"
+            data = FileProvider.getUriForFile(context, authority, outputFile)
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP
+        })
+
+    }
+
+    fun release() {
+        recorder.release()
+        recorderSurface.release()
+    }
+
+    companion object {
+        val TAG = VideoRecorder::class.java.simpleName
+        const val RECORDER_VIDEO_BITRATE: Int = 10_000_000
+        const val MIN_REQUIRED_RECORDING_TIME_MILLIS: Long = 5000L
+
+        /** Creates a [File] named with the current date and time */
+        private fun createFile(context: Context, extension: String): File {
+            val sdf = SimpleDateFormat("yyyy_MM_dd_HH_mm_ss_SSS", Locale.US)
+            return File(context.filesDir, "VID_${sdf.format(Date())}.$extension")
+        }
+    }
 }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -27,8 +27,9 @@ class VideoRecorder(
     /** 出力ファイルパス。省略時は自動で生成します。 */
     outputFile: File? = null
 ) {
+    /** 利用側でプレビューなどに使うsurface群 */
+    private var extraSurfaces = ArrayList<Surface>()
     private lateinit var session: CameraCaptureSession
-    private lateinit var previewSurface: Surface
     /** Live data listener for changes in the device orientation relative to the camera */
     private lateinit var relativeOrientation: OrientationLiveData
 
@@ -75,8 +76,8 @@ class VideoRecorder(
     private val recordRequest: CaptureRequest by lazy {
         // Capture request holds references to target surfaces
         session.device.createCaptureRequest(CameraDevice.TEMPLATE_RECORD).apply {
-            // Add the preview and recording surface targets
-            addTarget(previewSurface)
+            // Add the recording surface and extra surfaces targets
+            extraSurfaces.forEach { addTarget(it) }
             addTarget(recorderSurface)
             // Sets user requested FPS for all targets
             set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(videoFps, videoFps))
@@ -147,8 +148,8 @@ class VideoRecorder(
         recorderSurface.release()
     }
 
-    fun prepare(session: CameraCaptureSession, previewSurface: Surface, relativeOrientation: OrientationLiveData) {
-        this.previewSurface = previewSurface
+    fun prepare(session: CameraCaptureSession, extraSurfaces: List<Surface> = emptyList(), relativeOrientation: OrientationLiveData) {
+        this.extraSurfaces = ArrayList(extraSurfaces)
         this.session = session
         this.relativeOrientation = relativeOrientation
     }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -9,7 +9,6 @@ import android.media.MediaCodec
 import android.media.MediaRecorder
 import android.media.MediaScannerConnection
 import android.net.Uri
-import android.util.Log
 import android.util.Range
 import android.util.Size
 import android.view.Surface
@@ -114,14 +113,12 @@ class VideoRecorder(
 
         // Finalizes recorder setup and starts recording
         recorder.apply {
-            Log.d(TAG, "inomata Recorder started.")
             // Sets output orientation based on current sensor value at start time
             relativeOrientation.value?.let { setOrientationHint(it) }
             prepare()
             start()
         }
         recordingStartMillis = System.currentTimeMillis()
-        Log.d(TAG, "Recording started")
     }
 
     /**
@@ -135,7 +132,6 @@ class VideoRecorder(
             delay(MIN_REQUIRED_RECORDING_TIME_MILLIS - elapsedTimeMillis)
         }
 
-        Log.d(TAG, "Recording stopped. Output file: $outputFile")
         recorder.stop()
 
         // Broadcasts the media file to the rest of the system
@@ -157,7 +153,6 @@ class VideoRecorder(
     }
 
     companion object {
-        val TAG = VideoRecorder::class.java.simpleName
         const val RECORDER_VIDEO_BITRATE: Int = 10_000_000
         const val MIN_REQUIRED_RECORDING_TIME_MILLIS: Long = 5000L
 

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -125,7 +125,7 @@ class VideoRecorder(
         Log.d(TAG, "Recording started")
     }
 
-    suspend fun stopRecording() {
+    suspend fun stopRecording(): File {
         // Requires recording of at least MIN_REQUIRED_RECORDING_TIME_MILLIS
         val elapsedTimeMillis = System.currentTimeMillis() - recordingStartMillis
         if (elapsedTimeMillis < VideoRecorder.MIN_REQUIRED_RECORDING_TIME_MILLIS) {
@@ -139,17 +139,7 @@ class VideoRecorder(
         MediaScannerConnection.scanFile(
                 context, arrayOf(outputFile.absolutePath), null, null)
 
-        // Launch external activity via intent to play video recorded using our provider
-        context.startActivity(Intent().apply {
-            action = Intent.ACTION_VIEW
-            type = MimeTypeMap.getSingleton()
-                    .getMimeTypeFromExtension(outputFile.extension)
-            val authority = "${BuildConfig.APPLICATION_ID}.provider"
-            data = FileProvider.getUriForFile(context, authority, outputFile)
-            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP
-        })
-
+        return outputFile
     }
 
     fun release() {

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorder.kt
@@ -83,12 +83,13 @@ class VideoRecorder(
         }.build()
     }
     /** Creates a [MediaRecorder] instance using the provided [Surface] as input */
-    fun createRecorder(surface: Surface, dummy: Boolean = false) = MediaRecorder().apply {
+    private fun createRecorder(surface: Surface, dummy: Boolean = false) = MediaRecorder().apply {
         setAudioSource(MediaRecorder.AudioSource.MIC)
         setVideoSource(MediaRecorder.VideoSource.SURFACE)
         setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
         setOutputFile(outputFile.absolutePath)
-        setVideoEncodingBitRate(VideoRecorder.RECORDER_VIDEO_BITRATE)
+        setAudioSamplingRate(AUDIO_SAMPLING_RATE)
+        setVideoEncodingBitRate(VideoRecorder.VIDEO_BITRATE)
         if (videoFps > 0) setVideoFrameRate(videoFps)
         setVideoSize(videoSize.width, videoSize.height)
         setVideoEncoder(MediaRecorder.VideoEncoder.H264)
@@ -153,7 +154,8 @@ class VideoRecorder(
     }
 
     companion object {
-        const val RECORDER_VIDEO_BITRATE: Int = 10_000_000
+        const val VIDEO_BITRATE: Int = 10_000_000
+        const val AUDIO_SAMPLING_RATE: Int = 16_000
         const val MIN_REQUIRED_RECORDING_TIME_MILLIS: Long = 5000L
 
         /** Creates a [File] named with the current date and time */

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
@@ -1,5 +1,6 @@
 package com.example.android.camera2.video.recorder
 
+import android.util.Range
 import android.util.Size
 import java.io.File
 
@@ -7,7 +8,7 @@ data class VideoRecorderConfiguration (
     /** ビデオ録画サイズ */
     val videoSize: Size,
     /** ビデオ録画FPS。VideoCameraHelper::getFps()で計算可能です。 */
-    val videoFps: Int,
+    val videoFps: Range<Int>?,
     /** 音声録画するか */
     val withAudio: Boolean,
     /** 出力ファイルパス */

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
@@ -1,0 +1,11 @@
+package com.example.android.camera2.video.recorder
+
+import android.util.Size
+import java.io.File
+
+data class VideoRecorderConfiguration (
+    val videoSize: Size,
+    val videoFps: Int,
+    val withAudio: Boolean,
+    val outputFile: File
+)

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderConfiguration.kt
@@ -4,8 +4,12 @@ import android.util.Size
 import java.io.File
 
 data class VideoRecorderConfiguration (
+    /** ビデオ録画サイズ */
     val videoSize: Size,
+    /** ビデオ録画FPS。VideoCameraHelper::getFps()で計算可能です。 */
     val videoFps: Int,
+    /** 音声録画するか */
     val withAudio: Boolean,
+    /** 出力ファイルパス */
     val outputFile: File
 )

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -52,7 +52,7 @@ internal class VideoRecorderSessionImpl(
             extraSurfaces.forEach { addTarget(it) }
             addTarget(recorderSurface)
             // Sets user requested FPS for all targets
-            set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(configuration.videoFps, configuration.videoFps))
+            if (configuration.videoFps != null) set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, configuration.videoFps)
         }.build()
     }
 
@@ -137,4 +137,3 @@ internal class VideoRecorderSessionImpl(
         Log.d(TAG, msg)
     }
 }
-

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -37,9 +37,7 @@ internal class VideoRecorderSessionImpl(
     private val recorderSurface: Surface,
     /** 利用側でプレビューなどに使うsurface群 */
     private val extraSurfaces: ArrayList<Surface>,
-    private val session: CameraCaptureSession,
-    /** Live data listener for changes in the device orientation relative to the camera */
-    private val relativeOrientation: OrientationLiveData
+    private val session: CameraCaptureSession
 ): VideoRecorderSession {
 
     private var recordingStartMillis: Long = 0L
@@ -58,7 +56,7 @@ internal class VideoRecorderSessionImpl(
         }.build()
     }
 
-    suspend fun startRecording() {
+    suspend fun startRecording(orientationDegree: Int?) {
         mutex.withLock {
             recorder = mediaRecorderFactory.create(configuration, recorderSurface)
             // camera-samples サンプルでは setRepeatingRequest は listener=nullでもhandlerを指定していますが、
@@ -73,7 +71,7 @@ internal class VideoRecorderSessionImpl(
             // Finalizes recorder setup and starts recording
             recorder?.apply {
                 // Sets output orientation based on current sensor value at start time
-                relativeOrientation.value?.let { setOrientationHint(it) }
+                orientationDegree?.let { setOrientationHint(it) }
                 prepare()
                 start()
             }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -9,7 +9,6 @@ import android.media.MediaScannerConnection
 import android.util.Log
 import android.util.Range
 import android.view.Surface
-import com.example.android.camera.utils.OrientationLiveData
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -25,7 +25,14 @@ import java.util.*
  * インスタンスを解放するまえに、必ず cancel または stopRecording を実行して処理を終了させること。
  */
 interface VideoRecorderSession {
+    /**
+     * 録画停止する。
+     */
     suspend fun stopRecording(): File
+
+    /**
+     * 録画を中断する。
+     */
     fun cancel()
 }
 internal class VideoRecorderSessionImpl(

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -135,15 +135,13 @@ internal class VideoRecorderSessionImpl(
             // Requires recording of at least MIN_REQUIRED_RECORDING_TIME_MILLIS
             val elapsedTimeMillis = System.currentTimeMillis() - recordingStartMillis
             if (elapsedTimeMillis < MIN_REQUIRED_RECORDING_TIME_MILLIS) {
-                log("stopRecording(): delay-start")
                 delay(MIN_REQUIRED_RECORDING_TIME_MILLIS - elapsedTimeMillis)
-                log("stopRecording(): delay-end")
             }
 
             try {
                 recorder?.stop()
             } catch(e: RuntimeException) {
-                throw RecordingException("MediaRecorder stopped too early.", e)
+                throw RecordingException("MediaRecorder stopped too early. ${e.message}", e)
             } finally {
                 release()
             }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -104,10 +104,6 @@ internal class VideoRecorderSessionImpl(
                 release()
             }
 
-            // Broadcasts the media file to the rest of the system
-            MediaScannerConnection.scanFile(
-                    context, arrayOf(configuration.outputFile.absolutePath), null, null)
-
             return configuration.outputFile
         }
     }

--- a/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
+++ b/Camera2Video/app/src/main/java/com/example/android/camera2/video/recorder/VideoRecorderSession.kt
@@ -1,0 +1,144 @@
+package com.example.android.camera2.video.recorder
+
+import android.content.Context
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CaptureFailure
+import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.CaptureResult
+import android.hardware.camera2.TotalCaptureResult
+import android.media.MediaRecorder
+import android.media.MediaScannerConnection
+import android.os.Handler
+import android.util.Log
+import android.util.Range
+import android.view.Surface
+import com.example.android.camera.utils.OrientationLiveData
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.util.*
+
+internal class VideoRecorderSession(
+    private val context: Context,
+    private val configuration: VideoRecorderConfiguration,
+    private val mediaRecorderFactory: MediaRecorderFactory,
+    private val handler: Handler,
+    private val recorderSurface: Surface,
+    /** 利用側でプレビューなどに使うsurface群 */
+    private val extraSurfaces: ArrayList<Surface>,
+    private val session: CameraCaptureSession,
+    /** Live data listener for changes in the device orientation relative to the camera */
+    private val relativeOrientation: OrientationLiveData
+) {
+
+    private var recordingStartMillis: Long = 0L
+
+    private var recorder: MediaRecorder? = null
+
+    /** Requests used for preview and recording in the [CameraCaptureSession] */
+    private val recordRequest: CaptureRequest by lazy {
+        // Capture request holds references to target surfaces
+        session.device.createCaptureRequest(CameraDevice.TEMPLATE_RECORD).apply {
+            // Add the recording surface and extra surfaces targets
+            extraSurfaces.forEach { addTarget(it) }
+            addTarget(recorderSurface)
+            // Sets user requested FPS for all targets
+            set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(configuration.videoFps, configuration.videoFps))
+        }.build()
+    }
+
+    suspend fun startRecording() {
+        mutex.withLock {
+            recorder = mediaRecorderFactory.create(configuration, recorderSurface)
+            log("startRecording(): start")
+            // camera-samples サンプルでは setRepeatingRequest は listener=nullでもhandlerを指定していますが、
+            // ドキュメントからもAOSPソースからもhandlerはlistenerの反応スレッドを制御するためだけに使われるようなので、handlerは使わないことにしました。
+            // 参考: https://github.com/android/camera-samples/blob/master/Camera2Video/app/src/main/java/com/example/android/camera2/video/fragments/CameraFragment.kt#L254
+            // 参考: http://gerrit.aospextended.com/plugins/gitiles/AospExtended/platform_frameworks_base/+/25df673b849de374cf1de40250dfd8a48b7ac28b/core/java/android/hardware/camera2/impl/CameraDevice.java#269
+            // Start recording repeating requests, which will stop the ongoing preview
+            // repeating requests without having to explicitly call `session.stopRepeating`
+            // session.setRepeatingRequest(recordRequest, null, handler)
+            // session.setRepeatingRequest(recordRequest, null, null)
+            session.setRepeatingRequest(recordRequest, object: CameraCaptureSession.CaptureCallback() {
+                override fun onCaptureSequenceAborted(session: CameraCaptureSession, sequenceId: Int) {
+                    log("onCaptureSequenceAborted($session, $sequenceId)")
+                }
+
+                override fun onCaptureCompleted(session: CameraCaptureSession, request: CaptureRequest, result: TotalCaptureResult) {
+                    log("onCaptureCompleted($session, $request, $result)")
+                }
+
+                override fun onCaptureFailed(session: CameraCaptureSession, request: CaptureRequest, failure: CaptureFailure) {
+                    log("onCaptureFailed($session, $request, $failure)")
+                }
+
+                override fun onCaptureSequenceCompleted(session: CameraCaptureSession, sequenceId: Int, frameNumber: Long) {
+                    log("onCaptureSequenceCompleted($session, $sequenceId, $frameNumber)")
+                }
+
+                override fun onCaptureStarted(session: CameraCaptureSession, request: CaptureRequest, timestamp: Long, frameNumber: Long) {
+                    log("onCaptureStarted($session, $request, $timestamp, $frameNumber)")
+                }
+
+                override fun onCaptureProgressed(session: CameraCaptureSession, request: CaptureRequest, partialResult: CaptureResult) {
+                    log("onCaptureProgressed($session, $request, $partialResult)")
+                }
+
+                override fun onCaptureBufferLost(session: CameraCaptureSession, request: CaptureRequest, target: Surface, frameNumber: Long) {
+                    log("onCaptureBufferLost($session, $request, $target, $frameNumber)")
+                }
+            }, handler)
+
+            // Finalizes recorder setup and starts recording
+            recorder?.apply {
+                // Sets output orientation based on current sensor value at start time
+                relativeOrientation.value?.let { setOrientationHint(it) }
+                prepare()
+                start()
+            }
+            recordingStartMillis = System.currentTimeMillis()
+            log("startRecording(): end")
+        }
+    }
+
+    private val mutex = Mutex()
+
+    /**
+     * レコーディングを停止して、出力ファイルを返す。
+     * インスタンスあたりのoutputFileは固定(コンストラクタでの指定またはインスタンス化時の自動生成)なので、このメソッドは常に同一ファイルインスタンスを返します。
+     */
+    suspend fun stopRecording(): File {
+        mutex.withLock {
+            log("stopRecording(): start")
+            // Requires recording of at least MIN_REQUIRED_RECORDING_TIME_MILLIS
+            val elapsedTimeMillis = System.currentTimeMillis() - recordingStartMillis
+            if (elapsedTimeMillis < VideoRecorderSession.MIN_REQUIRED_RECORDING_TIME_MILLIS) {
+                log("stopRecording(): delay-start")
+                delay(MIN_REQUIRED_RECORDING_TIME_MILLIS - elapsedTimeMillis)
+                log("stopRecording(): delay-end")
+            }
+
+            recorder?.stop()
+
+            // Broadcasts the media file to the rest of the system
+            MediaScannerConnection.scanFile(
+                    context, arrayOf(configuration.outputFile.absolutePath), null, null)
+
+            log("stopRecording(): end")
+            recorder?.release()
+            recorder = null
+            return configuration.outputFile
+        }
+    }
+
+    companion object {
+        private val TAG = VideoRecorderSession::class.java.simpleName
+        private const val MIN_REQUIRED_RECORDING_TIME_MILLIS: Long = 5000L
+    }
+    private fun log(msg: String) {
+        Log.d(TAG, msg)
+    }
+}
+


### PR DESCRIPTION
## サンプルコードの問題修正
- start/stopを連打すると複数の理由によりクラッシュする
  - [x] MediaRecorder のステートで許されない操作をしている
    - stopしたらinit状態になるので、prepareからやり直さなければならない。
    - https://stackoverflow.com/questions/21632769/setoutputformat-called-in-an-invalid-state-4-where-and-why/21709635
   - [x] stop中にstartできてしまう
      - Mutex.withLock でstop/startが干渉しないようにする
  - [x] セーブ後のビューワ起動後に録画開始するとクラッシュする
     - onStopでの停止操作の結果、CameraDevice already stoppedで例外になる。 → カメラが止まった後に録画を中断させて、かつカメラ初期化後に MediaRecorderなどを作り直す必要がある。
     - requireActivity で fragment not attached で死ぬ。 → コルーチンに whenResumed を入れる。
- [x] setRepeatingRequest での不要なハンドラ指定の除去
    - ドキュメントにあるとおり、callback==nullならhandlerは使われないのでnullでよい。
    - http://gerrit.aospextended.com/plugins/gitiles/AospExtended/platform_frameworks_base/+/a636d84a33b323a9cde56d1a2f6c463f4eb26841/core/java/android/hardware/camera2/impl/CameraCaptureSessionImpl.java#283
  - 参考: 旧ソース http://gerrit.aospextended.com/plugins/gitiles/AospExtended/platform_frameworks_base/+/25df673b849de374cf1de40250dfd8a48b7ac28b/core/java/android/hardware/camera2/impl/CameraDevice.java#269

- 撮影終了 → プレビューを閉じて解像度選択に自動で戻る → 解像度選択でクラッシュ
   - サンプルのNavigation周りのエラーなので今回は無視する。
```
2020-08-13 20:11:53.611 8489-8489/com.android.example.camera2.video E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.android.example.camera2.video, PID: 8489
    java.lang.IllegalArgumentException: navigation destination com.android.example.camera2.video:id/action_selector_to_camera is unknown to this NavController
        at androidx.navigation.NavController.navigate(NavController.java:865)
        at androidx.navigation.NavController.navigate(NavController.java:806)
        at androidx.navigation.NavController.navigate(NavController.java:792)
        at androidx.navigation.NavController.navigate(NavController.java:987)
        at com.example.android.camera2.video.fragments.SelectorFragment$onViewCreated$$inlined$apply$lambda$1$1.onClick(SelectorFragment.kt:68)
```

- 録画時の音声オンオフを設定を切り替えれるようにした。